### PR TITLE
build(cloudflare): deploy as worker site

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"dev": "vinxi dev",
 		"build": "vinxi build",
 		"start": "wrangler dev",
+		"deploy": "wrangler deploy",
 		"format": "prettier --write ."
 	},
 	"dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@solidjs/start/config"
 export default defineConfig({
 	start: {
 		server: {
-			preset: "cloudflare_module",
+			preset: "cloudflare-module",
 			rollupConfig: {
 				external: ["__STATIC_CONTENT_MANIFEST", "node:async_hooks"],
 			},

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,6 @@
+name = "emmanuelchucks-com"
 main = "./.output/server/index.mjs"
+compatibility_date = "2023-12-28"
 compatibility_flags = ["nodejs_compat"]
 
 [site]


### PR DESCRIPTION
- correct use is worker site not pages
- i actually prefer it
- full access to cloudflare worker features
- cron, queues, etc
- perfect for longlink and bug project btw